### PR TITLE
Set up action_groups in meta/runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,10 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  k8s:
+  - kubevirt_cdi_upload
+  - kubevirt_preset
+  - kubevirt_pvc
+  - kubevirt_rs
+  - kubevirt_template
+  - kubevirt_vm


### PR DESCRIPTION
These allow for module_defaults to be used with the k8s group:
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups

@felixfontein has already taken care of adding community.kubevirt to Ansible for module defaults in https://github.com/ansible/ansible/pull/72496/