### PR TITLE
Add storageClassName and volumeMode to datavolumes

### DIFF
--- a/changelogs/fragments/add-missing-datavol-params.yaml
+++ b/changelogs/fragments/add-missing-datavol-params.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - kubevirt_vm - Adds missing storageClassName and volumeMode parameters to datavol class (https://github.com/ansible-collections/community.kubevirt/issues/12)
+  - kubevirt_vm - Adds missing ``storageClassName`` and ``volumeMode`` parameters to datavol class (https://github.com/ansible-collections/community.kubevirt/issues/12)

--- a/changelogs/fragments/add-missing-datavol-params.yaml
+++ b/changelogs/fragments/add-missing-datavol-params.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - kubevirt_vm - Adds missing storageClassName and volumeMode parameters to datavol class (https://github.com/ansible-collections/community.kubevirt/issues/12)

--- a/plugins/module_utils/kubevirt.py
+++ b/plugins/module_utils/kubevirt.py
@@ -167,7 +167,7 @@ class KubeVirtRawModule(KubernetesRawModule):
 
     def _define_datavolumes(self, datavolumes, spec):
         """
-        Takes datavoulmes parameter of Ansible and create kubevirt API datavolumesTemplateSpec
+        Takes datavolumes parameter of Ansible and create kubevirt API datavolumesTemplateSpec
         structure from it
         """
         if not datavolumes:
@@ -180,6 +180,8 @@ class KubeVirtRawModule(KubernetesRawModule):
             dvt['metadata']['name'] = dv.get('name')
             dvt['spec']['pvc'] = {
                 'accessModes': dv.get('pvc').get('accessModes'),
+                'storageClassName': dv.get('pvc').get('storageClassName'),
+                'volumeMode': dv.get('pvc').get('volumeMode'),
                 'resources': {
                     'requests': {
                         'storage': dv.get('pvc').get('storage'),


### PR DESCRIPTION


##### SUMMARY
Currently the code ignores additional parameters and both
storageClassName and volumeMode are commonly used. This commit
adds them.

Fixes #12

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
kubevirt_vm

##### ADDITIONAL INFORMATION
N/A
