### PR TITLE
Promote datavol over cloudinit

### DIFF
--- a/changelogs/fragments/promote-datavol-over-cloudinit.yaml
+++ b/changelogs/fragments/promote-datavol-over-cloudinit.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - kubevirt_vm - Create datavol before cloudinit disk as its more likely to be a boot volume
+  - kubevirt_vm - Create datavol before cloudinit disk as its more likely to be a boot volume (https://github.com/ansible-collections/community.kubevirt/pull/20)

--- a/changelogs/fragments/promote-datavol-over-cloudinit.yaml
+++ b/changelogs/fragments/promote-datavol-over-cloudinit.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - kubevirt_vm - Create datavol before cloudinit disk as its more likely to be a boot volume

--- a/plugins/module_utils/kubevirt.py
+++ b/plugins/module_utils/kubevirt.py
@@ -429,6 +429,9 @@ class KubeVirtRawModule(KubernetesRawModule):
         # Define disks
         self._define_disks(disks, template_spec, defaults)
 
+        # Define datavolumes:
+        self._define_datavolumes(datavolumes, definition['spec'])
+
         # Define cloud init disk if defined:
         # Note, that this must be called after _define_disks, so the cloud_init
         # is not first in order and it's not used as boot disk:
@@ -436,9 +439,6 @@ class KubeVirtRawModule(KubernetesRawModule):
 
         # Define interfaces:
         self._define_interfaces(interfaces, template_spec, defaults)
-
-        # Define datavolumes:
-        self._define_datavolumes(datavolumes, definition['spec'])
 
         return self.merge_dicts(definition, self.resource_definitions[0])
 

--- a/plugins/module_utils/kubevirt.py
+++ b/plugins/module_utils/kubevirt.py
@@ -167,7 +167,7 @@ class KubeVirtRawModule(KubernetesRawModule):
 
     def _define_datavolumes(self, datavolumes, spec):
         """
-        Takes datavoulmes parameter of Ansible and create kubevirt API datavolumesTemplateSpec
+        Takes datavolumes parameter of Ansible and create kubevirt API datavolumesTemplateSpec
         structure from it
         """
         if not datavolumes:
@@ -180,6 +180,8 @@ class KubeVirtRawModule(KubernetesRawModule):
             dvt['metadata']['name'] = dv.get('name')
             dvt['spec']['pvc'] = {
                 'accessModes': dv.get('pvc').get('accessModes'),
+                'storageClassName': dv.get('pvc').get('storageClassName'),
+                'volumeMode': dv.get('pvc').get('volumeMode'),
                 'resources': {
                     'requests': {
                         'storage': dv.get('pvc').get('storage'),


### PR DESCRIPTION
##### SUMMARY

Volume boot order defaults to creation order in vm definition so we want to move datavolumes higher up than cloud-init volumes as its unlikely users will want to boot from these. Setting the boot order on a datavol is also non-trivial.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
kubevirt_vm

##### ADDITIONAL INFORMATION
Attempt to boot a kubevirt vm with both a datavol and a cloudinit vol. The cloudinit vol will be created first and therefore the vm attempts to boot from this and fails.
