### PR TITLE
Rename k8s dependency

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -57,7 +57,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install collection dependencies
-        run: ansible-galaxy collection install 'community.kubernetes:<2.0.0' -p .
+        run: ansible-galaxy collection install 'kubernetes.core:<2.0.0' -p .
 
       # run ansible-test sanity inside of Docker.
       # The docker container has all the pinned dependencies that are required
@@ -98,7 +98,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install collection dependencies
-        run: ansible-galaxy collection install 'community.kubernetes:<2.0.0' -p .
+        run: ansible-galaxy collection install 'kubernetes.core:<2.0.0' -p .
 
       # Run the unit tests
       - name: Run unit test
@@ -162,7 +162,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install collection dependencies
-        run: ansible-galaxy collection install 'community.kubernetes:<2.0.0' -p .
+        run: ansible-galaxy collection install 'kubernetes.core:<2.0.0' -p .
 
       # Run the integration tests
       - name: Run integration test

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ authors:
   - kubevirt (github.com/kubevirt)
   - tima (github.com/tima)
 dependencies:
-  community.kubernetes: '>=1.0.0,<2.0.0'
+  kubernetes.core: '>=1.0.0,<2.0.0'
 description: 
 license_file: LICENSE
 tags:

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -140,7 +140,7 @@ connections:
 
 import json
 
-from ansible_collections.community.kubernetes.plugins.inventory.k8s import K8sInventoryException, InventoryModule as K8sInventoryModule, format_dynamic_api_exc
+from ansible_collections.kubernetes.core.plugins.inventory.k8s import K8sInventoryException, InventoryModule as K8sInventoryModule, format_dynamic_api_exc
 
 try:
     from openshift.dynamic.exceptions import DynamicApiError

--- a/plugins/module_utils/kubevirt.py
+++ b/plugins/module_utils/kubevirt.py
@@ -11,8 +11,8 @@ from distutils.version import Version
 
 from ansible.module_utils.common import dict_transformations
 from ansible.module_utils.common._collections_compat import Sequence
-from ansible_collections.community.kubernetes.plugins.module_utils.common import list_dict_str
-from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
+from ansible_collections.kubernetes.core.plugins.module_utils.common import list_dict_str
+from ansible_collections.kubernetes.core.plugins.module_utils.raw import KubernetesRawModule
 
 import copy
 import re

--- a/plugins/modules/kubevirt_cdi_upload.py
+++ b/plugins/modules/kubevirt_cdi_upload.py
@@ -53,7 +53,7 @@ options:
     choices: [ json, merge, strategic-merge ]
 
 extends_documentation_fragment:
-- community.kubernetes.k8s_auth_options
+- kubernetes.core.k8s_auth_options
 
 
 requirements:
@@ -79,8 +79,8 @@ import traceback
 
 from collections import defaultdict
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
-from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
+from ansible_collections.kubernetes.core.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.kubernetes.core.plugins.module_utils.raw import KubernetesRawModule
 
 # 3rd party imports
 try:

--- a/plugins/modules/kubevirt_preset.py
+++ b/plugins/modules/kubevirt_preset.py
@@ -45,7 +45,7 @@ options:
         type: dict
 
 extends_documentation_fragment:
-- community.kubernetes.k8s_auth_options
+- kubernetes.core.k8s_auth_options
 - community.kubevirt.kubevirt_vm_options
 - community.kubevirt.kubevirt_common_options
 
@@ -88,7 +88,7 @@ import copy
 import traceback
 
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.kubernetes.core.plugins.module_utils.common import AUTH_ARG_SPEC
 
 from ansible_collections.community.kubevirt.plugins.module_utils.kubevirt import (
     virtdict,

--- a/plugins/modules/kubevirt_pvc.py
+++ b/plugins/modules/kubevirt_pvc.py
@@ -138,7 +138,7 @@ options:
     default: 300
 
 extends_documentation_fragment:
-- community.kubernetes.k8s_auth_options
+- kubernetes.core.k8s_auth_options
 
 
 requirements:
@@ -250,8 +250,8 @@ import traceback
 
 from collections import defaultdict
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
-from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
+from ansible_collections.kubernetes.core.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.kubernetes.core.plugins.module_utils.raw import KubernetesRawModule
 from ansible_collections.community.kubevirt.plugins.module_utils.kubevirt import virtdict, KubeVirtRawModule
 
 

--- a/plugins/modules/kubevirt_rs.py
+++ b/plugins/modules/kubevirt_rs.py
@@ -51,7 +51,7 @@ options:
         type: int
 
 extends_documentation_fragment:
-- community.kubernetes.k8s_auth_options
+- kubernetes.core.k8s_auth_options
 - community.kubevirt.kubevirt_vm_options
 - community.kubevirt.kubevirt_common_options
 
@@ -107,7 +107,7 @@ import copy
 import traceback
 
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.kubernetes.core.plugins.module_utils.common import AUTH_ARG_SPEC
 
 from ansible_collections.community.kubevirt.plugins.module_utils.kubevirt import (
     virtdict,

--- a/plugins/modules/kubevirt_template.py
+++ b/plugins/modules/kubevirt_template.py
@@ -133,8 +133,8 @@ options:
         type: str
 
 extends_documentation_fragment:
-- community.kubernetes.k8s_auth_options
-- community.kubernetes.k8s_state_options
+- kubernetes.core.k8s_auth_options
+- kubernetes.core.k8s_state_options
 
 
 requirements:
@@ -201,7 +201,7 @@ kubevirt_template:
 import copy
 import traceback
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.kubernetes.core.plugins.module_utils.common import AUTH_ARG_SPEC
 
 from ansible_collections.community.kubevirt.plugins.module_utils.kubevirt import (
     virtdict,

--- a/plugins/modules/kubevirt_vm.py
+++ b/plugins/modules/kubevirt_vm.py
@@ -67,7 +67,7 @@ options:
         type: dict
 
 extends_documentation_fragment:
-- community.kubernetes.k8s_auth_options
+- kubernetes.core.k8s_auth_options
 - community.kubevirt.kubevirt_vm_options
 - community.kubevirt.kubevirt_common_options
 
@@ -245,7 +245,7 @@ kubevirt_vm:
 import copy
 import traceback
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.kubernetes.core.plugins.module_utils.common import AUTH_ARG_SPEC
 from ansible_collections.community.kubevirt.plugins.module_utils.kubevirt import (
     virtdict,
     KubeVirtRawModule,

--- a/tests/unit/plugins/modules/kubevirt_fixtures.py
+++ b/tests/unit/plugins/modules/kubevirt_fixtures.py
@@ -6,8 +6,8 @@ import pytest
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.kubevirt.tests.unit.compat.mock import MagicMock
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import K8sAnsibleMixin
-from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
+from ansible_collections.kubernetes.core.plugins.module_utils.common import K8sAnsibleMixin
+from ansible_collections.kubernetes.core.plugins.module_utils.raw import KubernetesRawModule
 from ansible_collections.community.kubevirt.plugins.module_utils.kubevirt import KubeVirtRawModule
 
 import openshift.dynamic

--- a/tests/unit/plugins/modules/test_kubevirt_rs.py
+++ b/tests/unit/plugins/modules/test_kubevirt_rs.py
@@ -8,7 +8,7 @@ openshiftdynamic = pytest.importorskip("openshift.dynamic")
 from ansible_collections.community.kubevirt.tests.unit.plugins.modules.utils import set_module_args
 from .kubevirt_fixtures import base_fixture, RESOURCE_DEFAULT_ARGS, AnsibleExitJson
 
-from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
+from ansible_collections.kubernetes.core.plugins.module_utils.raw import KubernetesRawModule
 from ansible_collections.community.kubevirt.plugins.modules import kubevirt_rs as mymodule
 
 KIND = 'VirtualMachineInstanceReplicaSet'


### PR DESCRIPTION
The community.kubernetes collection has been renamed to kubernetes.core and this commit just makes sure the collection will not get stuck with the old name.

Do note that we had to introduce an upper bound in the requirements since the kubernetes.core broke backward compatibility with version 2.0.0.

~Depends on #26~

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request